### PR TITLE
fix string-related UB

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,3 @@ mkdir -p build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j20
-cp gen-yul-json-ast ../

--- a/gen-yul-json-ast.cpp
+++ b/gen-yul-json-ast.cpp
@@ -68,7 +68,7 @@ solidity::langutil::CharStream generateIR(char const* sol_filepath)
 	}
 	ir.remove_prefix(IR_HEADER.size());
 
-	return solidity::langutil::CharStream{ir.data(), "ir_stream"};
+	return solidity::langutil::CharStream{std::string{ir}, "ir_stream"};
 }
 
 


### PR DESCRIPTION
Problem: `string_view::data` doesn't return a null-terminated c
     string. It returns a pointer to a char array that doesn't
     necessarily end with a \0. It is incorrect to construct
     `std::string` from raw `ir.data()`, because it constructs a
     string from the given pointer up to the next \0 character.

Solution: use string_view specific std::string constructor, that takes
     string_view::size into consideration.